### PR TITLE
Prevent shape mismatch in segment-input

### DIFF
--- a/keras_bert/bert.py
+++ b/keras_bert/bert.py
@@ -174,7 +174,7 @@ def gen_batch_inputs(sentence_pairs,
     mlm_outputs = []
     for i in range(batch_size):
         first, second = sentence_pairs[i][0], sentence_pairs[mapping.get(i, i)][1]
-        segment_inputs.append([0] * (len(first) + 2) + [1] * (seq_len - (len(first) + 2)))
+        segment_inputs.append(([0] * (len(first) + 2) + [1] * (seq_len - (len(first) + 2)))[:seq_len])
         tokens = [TOKEN_CLS] + first + [TOKEN_SEP] + second + [TOKEN_SEP]
         tokens = tokens[:seq_len]
         tokens += [TOKEN_PAD] * (seq_len - len(tokens))


### PR DESCRIPTION
Prevented the length of the vector from exceeding seq_len using the same method applied to tokens (tokens = tokens[:seq_len])