### PR TITLE
Improve BERT tokenizer: fixed truncation, split into smaller methods

### DIFF
--- a/keras_bert/tokenizer.py
+++ b/keras_bert/tokenizer.py
@@ -10,36 +10,62 @@ class Tokenizer(object):
                  token_sep=TOKEN_SEP,
                  token_unk=TOKEN_UNK,
                  pad_index=0):
-        self.token_dict = token_dict
-        self.token_cls = token_cls
-        self.token_sep = token_sep
-        self.token_unk = token_unk
-        self.pad_index = pad_index
+        self._token_dict = token_dict
+        self._token_cls = token_cls
+        self._token_sep = token_sep
+        self._token_unk = token_unk
+        self._pad_index = pad_index
+
+    @staticmethod
+    def _truncate(first_tokens, second_tokens=None, max_len=None):
+        if max_len is None:
+            return
+
+        if second_tokens is not None:
+            while True:
+                total_len = len(first_tokens) + len(second_tokens)
+                if total_len <= max_len - 3:  # 3 for [CLS] .. tokens_a .. [SEP] .. tokens_b [SEP]
+                    break
+                if len(first_tokens) > len(second_tokens):
+                    first_tokens.pop()
+                else:
+                    second_tokens.pop()
+        else:
+            del first_tokens[max_len - 2:]  # 2 for [CLS] .. tokens .. [SEP]
+
+    def _pack(self, first_tokens, second_tokens=None):
+        first_packed_tokens = [self._token_cls] + first_tokens + [self._token_sep]
+        if second_tokens is not None:
+            second_packed_tokens = second_tokens + [self._token_sep]
+            return first_packed_tokens + second_packed_tokens, len(first_packed_tokens), len(second_packed_tokens)
+        else:
+            return first_packed_tokens, len(first_packed_tokens), 0
+
+    def _convert_tokens_to_ids(self, tokens):
+        unk_id = self._token_dict.get(self._token_unk)
+        return [self._token_dict.get(token, unk_id) for token in tokens]
 
     def tokenize(self, first, second=None):
-        tokens = [self.token_cls] + self._tokenize(first) + [self.token_sep]
-        if second is not None:
-            tokens += self._tokenize(second) + [self.token_sep]
+        first_tokens = self._tokenize(first)
+        second_tokens = self._tokenize(second) if second is not None else None
+        tokens, _, _ = self._pack(first_tokens, second_tokens)
         return tokens
 
     def encode(self, first, second=None, max_len=None):
-        tokens = self.tokenize(first, second)
-        unknown_index = self.token_dict.get(self.token_unk)
-        indices = [self.token_dict.get(token, unknown_index) for token in tokens]
-        sep = len(tokens)
-        for i in range(len(tokens)):
-            if tokens[i] == self.token_sep:
-                sep = i + 1
-                break
-        segments = [0] * sep + [1] * (len(tokens) - sep)
+        first_tokens = self._tokenize(first)
+        second_tokens = self._tokenize(second) if second is not None else None
+        self._truncate(first_tokens, second_tokens, max_len)
+        tokens, first_len, second_len = self._pack(first_tokens, second_tokens)
+
+        token_ids = self._convert_tokens_to_ids(tokens)
+        segment_ids = [0] * first_len + [1] * second_len
+
         if max_len is not None:
-            if len(indices) < max_len:
-                indices += [self.pad_index] * (max_len - len(indices))
-                segments += [1] * (max_len - len(segments))
-            elif len(indices) > max_len:
-                indices = indices[:max_len]
-                segments = segments[:max_len]
-        return indices, segments
+            pad_len = max_len - first_len - second_len
+            token_ids += [self._pad_index] * pad_len
+            segment_ids += [0] * pad_len
+
+        return token_ids, segment_ids
 
     def _tokenize(self, text):
         text = unicodedata.normalize('NFD', text)
@@ -61,7 +87,7 @@ class Tokenizer(object):
         return tokens
 
     def _word_piece_tokenize(self, word):
-        if word in self.token_dict:
+        if word in self._token_dict:
             return [word]
         tokens = []
         start, stop = 0, 0
@@ -71,7 +97,7 @@ class Tokenizer(object):
                 sub = word[start:stop]
                 if start > 0:
                     sub = '##' + sub
-                if sub in self.token_dict:
+                if sub in self._token_dict:
                     break
                 stop -= 1
             if start == stop:

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -35,11 +35,11 @@ class TestTokenizer(TestCase):
         indices, segments = tokenizer.encode(first=text, second=text, max_len=100)
         expected = [2, 1, 1, 3, 1, 1, 3] + [0] * 93
         self.assertEqual(expected, indices)
-        expected = [0, 0, 0, 0, 1, 1, 1] + [1] * 93
+        expected = [0, 0, 0, 0, 1, 1, 1] + [0] * 93
         self.assertEqual(expected, segments)
         indices, segments = tokenizer.encode(first=text, second=text, max_len=4)
-        self.assertEqual([2, 1, 1, 3], indices)
-        self.assertEqual([0, 0, 0, 0], segments)
+        self.assertEqual([2, 1, 3, 3], indices)
+        self.assertEqual([0, 0, 0, 1], segments)
 
     def test_empty(self):
         tokens = ['[PAD]', '[UNK]', '[CLS]', '[SEP]']

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -32,6 +32,16 @@ class TestTokenizer(TestCase):
         token_dict = {token: i for i, token in enumerate(tokens)}
         tokenizer = Tokenizer(token_dict)
         text = u'\u535A\u63A8'
+        # single
+        indices, segments = tokenizer.encode(first=text, max_len=100)
+        expected = [2, 1, 1, 3] + [0] * 96
+        self.assertEqual(expected, indices)
+        expected = [0] * 100
+        self.assertEqual(expected, segments)
+        indices, segments = tokenizer.encode(first=text, max_len=3)
+        self.assertEqual([2, 1, 3], indices)
+        self.assertEqual([0, 0, 0], segments)
+        # paired
         indices, segments = tokenizer.encode(first=text, second=text, max_len=100)
         expected = [2, 1, 1, 3, 1, 1, 3] + [0] * 93
         self.assertEqual(expected, indices)


### PR DESCRIPTION
* Fix sequence length truncation to match official google-research/bert algorithm
* Split into smaller method to allow reuse and partial override in inherited classes.